### PR TITLE
make header responsive on small displays

### DIFF
--- a/index.css
+++ b/index.css
@@ -10,6 +10,7 @@ body {
 =========== */
 
 .container {
+    padding: 60px 0;
     width: 90%;
     max-width: 900px;
     margin: 0 auto;
@@ -112,9 +113,10 @@ nav ul {
     list-style: none;
     display: flex;
     justify-content: center;
+    padding: 0;
 }
 
-@media only screen and (max-width: 380px) {
+@media only screen and (max-width: 428px) {
     #menu-icon {
         display: none;
     }
@@ -155,7 +157,7 @@ header::before {
     content: "";
     background-color: rgba(0, 0, 0, 1);
     position: absolute;
-    height: 17%;
+    height: 50%;
     width: 100%;
     z-index: -1;
     opacity: 0.9;

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ HEADER
 
 
 
-    <header><br><br>
+    <header>
         <div class="container container-nav">
             <div>
                 <div class="title">
@@ -98,7 +98,7 @@ HEADER
                 </ul>
             </nav>
         </div>
-    </header><br><br>
+    </header>
 
 
 


### PR DESCRIPTION
-  Fixed the white space below header. 

-  Changed display of hamburger menu to hidden on smaller displays.

# Before 
![image](https://user-images.githubusercontent.com/60010655/194770412-05b89231-dacd-4f36-99dc-915f3638f116.png)

# After 

<img width="505" alt="after" src="https://user-images.githubusercontent.com/60010655/194770436-dd49efd4-4126-4d99-bfce-db202a5f9784.png">
